### PR TITLE
🐛 Fix Edit profile button cutoff and make spacing consistent

### DIFF
--- a/lib/pages/home/pages/profile/widgets/profile_card/widgets/profile_actions/profile_actions.dart
+++ b/lib/pages/home/pages/profile/widgets/profile_card/widgets/profile_actions/profile_actions.dart
@@ -22,7 +22,14 @@ class OBProfileActions extends StatelessWidget {
     List<Widget> actions = [];
 
     if (isLoggedInUser) {
-      actions.add(_buildEditButton(modalService, context));
+      actions.add(
+        Padding(
+          // The margin compensates for the height of the (missing) OBProfileActionMore
+          // Fixes cut-off Edit profile button, and level out layout distances
+          padding: EdgeInsets.only(top: 6.5, bottom: 6.5),
+          child: _buildEditButton(modalService, context),
+        )
+      );
     } else {
       actions.addAll([
         OBFollowButton(user),


### PR DESCRIPTION
Wraps the Edit profile button in a container with margin at the top and bottom. This fixes the Edit profile button being cut-off at the top, and makes the spacing consistent with the profile of another user.

The container and padding should be removed if your own profile also gets a `OBProfileActionMore` in the future.

Below a screenshot with the before and after.
<img width="1168" alt="Screenshot 2019-03-29 at 15 22 42" src="https://user-images.githubusercontent.com/13038653/55243078-cc447800-523e-11e9-87e7-b8a6dd37b0ac.png">
