### PR TITLE
:recycle: use sort agnostic function names and support both types of …

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -37,7 +37,7 @@ PODS:
 
 DEPENDENCIES:
   - device_info (from `.symlinks/plugins/device_info/ios`)
-  - Flutter (from `.symlinks/flutter/ios-release`)
+  - Flutter (from `.symlinks/flutter/ios`)
   - flutter_exif_rotation (from `.symlinks/plugins/flutter_exif_rotation/ios`)
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - image_cropper (from `.symlinks/plugins/image_cropper/ios`)
@@ -62,7 +62,7 @@ EXTERNAL SOURCES:
   device_info:
     :path: ".symlinks/plugins/device_info/ios"
   Flutter:
-    :path: ".symlinks/flutter/ios-release"
+    :path: ".symlinks/flutter/ios"
   flutter_exif_rotation:
     :path: ".symlinks/plugins/flutter_exif_rotation/ios"
   flutter_secure_storage:

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -703,7 +703,7 @@
 			);
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${PODS_ROOT}/../.symlinks/flutter/ios-release/Flutter.framework",
+				"${PODS_ROOT}/../.symlinks/flutter/ios/Flutter.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -388,7 +388,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0"
   petitparser:
     dependency: transitive
     description:
@@ -498,7 +498,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.4"
+    version: "1.5.5"
   sprintf:
     dependency: "direct main"
     description:
@@ -675,5 +675,5 @@ packages:
     source: hosted
     version: "2.1.15"
 sdks:
-  dart: ">=2.1.0 <3.0.0"
+  dart: ">=2.1.1-dev.0.0 <3.0.0"
   flutter: ">=1.2.1 <2.0.0"


### PR DESCRIPTION
Widget now contains the following functions, all of these take into account whichever sorting is currently applicable no matter what.
1.`_refreshCommentsSlice` -> first load
2.`_loadMoreBottomComments`
3.`_loadMoreTopComments`
4.`_onWantsToRefreshComments` -> for refresh indicator.

For toggling sort, we persist this now in `_userPreferencesService`
5. `_onWantsToToggleSortComments`

And to insert a newly posted comment, since we need to configure the request separately depending on the sort.. there is a `__refreshCommentsWithCreatedPostCommentVisible`
This makes sure the created comment is visible. A regular refresh comments (4.) will just get the comments from one end of the list depending on sort.
