### PR TITLE
🐛 Fix Photopicker cutoff on iPhone X and newer

### DIFF
--- a/lib/pages/home/bottom_sheets/photo_picker.dart
+++ b/lib/pages/home/bottom_sheets/photo_picker.dart
@@ -57,10 +57,13 @@ class OBPhotoPickerBottomSheet extends StatelessWidget {
 
     return OBPrimaryColorContainer(
       mainAxisSize: MainAxisSize.min,
-      child: Column(
-        children: photoPickerActions,
-        mainAxisSize: MainAxisSize.min,
-      ),
+      child: Padding(
+        padding: EdgeInsets.only(bottom: 16),
+        child: Column(
+          children: photoPickerActions,
+          mainAxisSize: MainAxisSize.min,
+          ),
+        )
     );
   }
 }

--- a/lib/pages/home/bottom_sheets/video_picker.dart
+++ b/lib/pages/home/bottom_sheets/video_picker.dart
@@ -40,10 +40,13 @@ class OBVideoPickerBottomSheet extends StatelessWidget {
 
     return OBPrimaryColorContainer(
       mainAxisSize: MainAxisSize.min,
-      child: Column(
-        children: videoPickerActions,
-        mainAxisSize: MainAxisSize.min,
-      ),
+      child: Padding(
+        padding: EdgeInsets.only(bottom: 16),
+        child: Column(
+          children: videoPickerActions,
+          mainAxisSize: MainAxisSize.min,
+          ),
+        )
     );
   }
 }

--- a/lib/pages/home/modals/create_post/create_post.dart
+++ b/lib/pages/home/modals/create_post/create_post.dart
@@ -47,9 +47,11 @@ class CreatePostModalState extends State<CreatePostModal> {
   UserService _userService;
 
   TextEditingController _textController;
+  FocusNode _focusNode;
   int _charactersCount;
 
   bool _isPostTextAllowedLength;
+  bool _hasFocus;
   bool _hasImage;
   bool _hasVideo;
   File _postImage;
@@ -67,11 +69,14 @@ class CreatePostModalState extends State<CreatePostModal> {
     super.initState();
     _textController = TextEditingController();
     _textController.addListener(_onPostTextChanged);
+    _focusNode = FocusNode();
+    _focusNode.addListener(_onFocusNodeChanged);
+    _hasFocus = false;
     _charactersCount = 0;
     _isPostTextAllowedLength = false;
     _hasImage = false;
     _hasVideo = false;
-    _postItemsWidgets = [OBCreatePostText(controller: _textController)];
+    _postItemsWidgets = [OBCreatePostText(controller: _textController, focusNode: _focusNode)];
 
     if (widget.community != null)
       _postItemsWidgets.add(OBPostCommunityPreviewer(
@@ -87,6 +92,7 @@ class CreatePostModalState extends State<CreatePostModal> {
   void dispose() {
     super.dispose();
     _textController.removeListener(_onPostTextChanged);
+    _focusNode.removeListener(_onFocusNodeChanged);
   }
 
   @override
@@ -213,8 +219,8 @@ class CreatePostModalState extends State<CreatePostModal> {
     if (postActions.isEmpty) return const SizedBox();
 
     return Container(
-      height: 83.0,
-      padding: EdgeInsets.only(top: 24.0, bottom: 24.0),
+      height: _hasFocus == true ? 51 : 67,
+      padding: EdgeInsets.only(top: 8.0, bottom: _hasFocus == true ? 8 : 24),
       color: Color.fromARGB(5, 0, 0, 0),
       child: ListView.separated(
         physics: const ClampingScrollPhysics(),
@@ -266,6 +272,10 @@ class CreatePostModalState extends State<CreatePostModal> {
       _isPostTextAllowedLength =
           _validationService.isPostTextAllowedLength(text);
     });
+  }
+
+  void _onFocusNodeChanged() {
+    _hasFocus = _focusNode.hasFocus;
   }
 
   void _setPostImage(File image) {

--- a/lib/pages/home/modals/create_post/create_post.dart
+++ b/lib/pages/home/modals/create_post/create_post.dart
@@ -213,8 +213,8 @@ class CreatePostModalState extends State<CreatePostModal> {
     if (postActions.isEmpty) return const SizedBox();
 
     return Container(
-      height: 51.0,
-      padding: EdgeInsets.only(top: 8.0, bottom: 8.0),
+      height: 83.0,
+      padding: EdgeInsets.only(top: 24.0, bottom: 24.0),
       color: Color.fromARGB(5, 0, 0, 0),
       child: ListView.separated(
         physics: const ClampingScrollPhysics(),

--- a/lib/pages/home/modals/create_post/widgets/create_post_text.dart
+++ b/lib/pages/home/modals/create_post/widgets/create_post_text.dart
@@ -5,9 +5,10 @@ import 'package:flutter/material.dart';
 
 class OBCreatePostText extends StatelessWidget {
   final TextEditingController controller;
+  final FocusNode focusNode;
   String hintText;
 
-  OBCreatePostText({this.controller, this.hintText});
+  OBCreatePostText({this.controller, this.focusNode, this.hintText});
 
   @override
   Widget build(BuildContext context) {
@@ -24,6 +25,7 @@ class OBCreatePostText extends StatelessWidget {
           return TextField(
             controller: controller,
             autofocus: true,
+            focusNode: focusNode,
             textCapitalization: TextCapitalization.sentences,
             keyboardType: TextInputType.multiline,
             maxLines: null,


### PR DESCRIPTION
This adds some padding to the photo picker in order to "fix" the cutoff on iPhone X and newer. 

Like @lifenautjoe mentioned in #182 detecting specific phones isn't pretty, so the padding is applied for all devices. 

For the post actions bar/container (bar with yellow photo button) the padding is also applied to the top, so it also remains symmetrical on other devices.

<img width="1168" alt="Screenshot 2019-03-29 at 19 23 25" src="https://user-images.githubusercontent.com/13038653/55254999-b55f4f00-5259-11e9-8d7f-e1bd2022f4f0.png">
<img width="1168" alt="Screenshot 2019-03-29 at 19 26 16" src="https://user-images.githubusercontent.com/13038653/55255006-b8f2d600-5259-11e9-8656-0a45ef315d42.png">
