### PR TITLE
🐛 Too large images are now rejected immediately

### DIFF
--- a/lib/pages/home/bottom_sheets/photo_picker.dart
+++ b/lib/pages/home/bottom_sheets/photo_picker.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:Openbook/provider.dart';
 import 'package:Openbook/services/image_picker.dart';
+import 'package:Openbook/services/toast.dart';
 import 'package:Openbook/widgets/icon.dart';
 import 'package:Openbook/widgets/theming/primary_color_container.dart';
 import 'package:Openbook/widgets/theming/text.dart';
@@ -17,6 +18,7 @@ class OBPhotoPickerBottomSheet extends StatelessWidget {
   Widget build(BuildContext context) {
     ImagePickerService imagePickerService =
         OpenbookProvider.of(context).imagePickerService;
+    ToastService toastService = OpenbookProvider.of(context).toastService;
 
     List<Widget> photoPickerActions = [
       ListTile(
@@ -25,9 +27,14 @@ class OBPhotoPickerBottomSheet extends StatelessWidget {
           'From gallery',
         ),
         onTap: () async {
-          File image = await imagePickerService.pickImage(
-              imageType: imageType, source: ImageSource.gallery);
-          Navigator.pop(context, image);
+          try {
+            File image = await imagePickerService.pickImage(
+                imageType: imageType, source: ImageSource.gallery);
+            Navigator.pop(context, image);
+          } on ImageTooLargeException catch (e) {
+            int limit = e.getLimitInMB();
+            toastService.error(message: 'Image to large (limit: $limit MB)', context: context);
+          }
         },
       ),
       ListTile(
@@ -36,9 +43,14 @@ class OBPhotoPickerBottomSheet extends StatelessWidget {
           'From camera',
         ),
         onTap: () async {
-          File image = await imagePickerService.pickImage(
-              imageType: imageType, source: ImageSource.camera);
-          Navigator.pop(context, image);
+          try {
+            File image = await imagePickerService.pickImage(
+                imageType: imageType, source: ImageSource.camera);
+            Navigator.pop(context, image);
+          } on ImageTooLargeException catch (e) {
+            int limit = e.getLimitInMB();
+            toastService.error(message: 'Image to large (limit: $limit MB)', context: context);
+          }
         },
       )
     ];

--- a/lib/pages/home/bottom_sheets/photo_picker.dart
+++ b/lib/pages/home/bottom_sheets/photo_picker.dart
@@ -33,7 +33,7 @@ class OBPhotoPickerBottomSheet extends StatelessWidget {
             Navigator.pop(context, image);
           } on ImageTooLargeException catch (e) {
             int limit = e.getLimitInMB();
-            toastService.error(message: 'Image to large (limit: $limit MB)', context: context);
+            toastService.error(message: 'Image too large (limit: $limit MB)', context: context);
           }
         },
       ),
@@ -49,7 +49,7 @@ class OBPhotoPickerBottomSheet extends StatelessWidget {
             Navigator.pop(context, image);
           } on ImageTooLargeException catch (e) {
             int limit = e.getLimitInMB();
-            toastService.error(message: 'Image to large (limit: $limit MB)', context: context);
+            toastService.error(message: 'Image too large (limit: $limit MB)', context: context);
           }
         },
       )

--- a/lib/pages/home/modals/edit_user_profile/edit_user_profile.dart
+++ b/lib/pages/home/modals/edit_user_profile/edit_user_profile.dart
@@ -325,7 +325,7 @@ class OBEditUserProfileModalState extends State<OBEditUserProfileModal> {
                   //if (image != null) createAccountBloc.avatar.add(image);
                 } on ImageTooLargeException catch(e) {
                   int limit = e.getLimitInMB();
-                  toastService.error(message: 'Image to large (limit: $limit MB)', context: context);
+                  toastService.error(message: 'Image too large (limit: $limit MB)', context: context);
                 }
                 Navigator.pop(context);
               },
@@ -340,7 +340,7 @@ class OBEditUserProfileModalState extends State<OBEditUserProfileModal> {
                   _onUserImageSelected(image: image, imageType: imageType);
                 } on ImageTooLargeException catch(e) {
                   int limit = e.getLimitInMB();
-                  toastService.error(message: 'Image to large (limit: $limit MB)', context: context);
+                  toastService.error(message: 'Image too large (limit: $limit MB)', context: context);
                 }
                 Navigator.pop(context);
               },

--- a/lib/pages/home/modals/edit_user_profile/edit_user_profile.dart
+++ b/lib/pages/home/modals/edit_user_profile/edit_user_profile.dart
@@ -308,6 +308,8 @@ class OBEditUserProfileModalState extends State<OBEditUserProfileModal> {
   }
 
   void _showImageBottomSheet({@required OBImageType imageType}) {
+    ToastService toastService = OpenbookProvider.of(context).toastService;
+
     showModalBottomSheet(
         context: context,
         builder: (BuildContext context) {
@@ -316,20 +318,30 @@ class OBEditUserProfileModalState extends State<OBEditUserProfileModal> {
               leading: new Icon(Icons.camera_alt),
               title: new Text('Camera'),
               onTap: () async {
-                var image = await _imagePickerService.pickImage(
-                    source: ImageSource.camera, imageType: imageType);
-                _onUserImageSelected(image: image, imageType: imageType);
+                try {
+                  var image = await _imagePickerService.pickImage(
+                      source: ImageSource.camera, imageType: imageType);
+                  _onUserImageSelected(image: image, imageType: imageType);
+                  //if (image != null) createAccountBloc.avatar.add(image);
+                } on ImageTooLargeException catch(e) {
+                  int limit = e.getLimitInMB();
+                  toastService.error(message: 'Image to large (limit: $limit MB)', context: context);
+                }
                 Navigator.pop(context);
-                //if (image != null) createAccountBloc.avatar.add(image);
               },
             ),
             new ListTile(
               leading: new Icon(Icons.photo_library),
               title: new Text('Gallery'),
               onTap: () async {
-                var image = await _imagePickerService.pickImage(
-                    source: ImageSource.gallery, imageType: imageType);
-                _onUserImageSelected(image: image, imageType: imageType);
+                try {
+                  var image = await _imagePickerService.pickImage(
+                      source: ImageSource.gallery, imageType: imageType);
+                  _onUserImageSelected(image: image, imageType: imageType);
+                } on ImageTooLargeException catch(e) {
+                  int limit = e.getLimitInMB();
+                  toastService.error(message: 'Image to large (limit: $limit MB)', context: context);
+                }
                 Navigator.pop(context);
               },
             )

--- a/lib/provider.dart
+++ b/lib/provider.dart
@@ -148,6 +148,7 @@ class OpenbookProviderState extends State<OpenbookProvider> {
     intercomService.setUserService(userService);
     dialogService.setThemeService(themeService);
     dialogService.setThemeValueParserService(themeValueParserService);
+    imagePickerService.setValidationService(validationService);
   }
 
   void initAsyncState() async {

--- a/lib/services/image_picker.dart
+++ b/lib/services/image_picker.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:image_cropper/image_cropper.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:meta/meta.dart';
+import 'package:Openbook/services/validation.dart';
 export 'package:image_picker/image_picker.dart';
 
 class ImagePickerService {
@@ -11,6 +12,12 @@ class ImagePickerService {
     OBImageType.cover: {'x': 16.0, 'y': 9.0}
   };
 
+  ValidationService _validationService;
+
+  void setValidationService(ValidationService validationService) {
+    _validationService = validationService;
+  }
+
   Future<File> pickImage(
       {@required OBImageType imageType,
       ImageSource source = ImageSource.gallery}) async {
@@ -18,6 +25,10 @@ class ImagePickerService {
 
     if (image == null) {
       return null;
+    }
+
+    if (!await _validationService.isImageAllowedSize(image, imageType)) {
+      throw ImageTooLargeException(_validationService.getAllowedImageSize(imageType));
     }
 
     double ratioX =
@@ -40,6 +51,19 @@ class ImagePickerService {
     var video = await ImagePicker.pickVideo(source: source);
 
     return video;
+  }
+}
+
+class ImageTooLargeException implements Exception {
+  final int limit;
+
+  const ImageTooLargeException(this.limit);
+
+  String toString() =>
+      'ImageToLargeException: Images can\'t be larger than $limit';
+
+  int getLimitInMB() {
+    return limit ~/ 1048576;
   }
 }
 

--- a/lib/services/validation.dart
+++ b/lib/services/validation.dart
@@ -1,8 +1,10 @@
+import 'dart:io';
 import 'package:Openbook/services/auth_api.dart';
 import 'package:Openbook/services/communities_api.dart';
 import 'package:Openbook/services/connections_circles_api.dart';
 import 'package:Openbook/services/follows_lists_api.dart';
 import 'package:Openbook/services/httpie.dart';
+import 'package:Openbook/services/image_picker.dart';
 import 'package:validators/validators.dart' as validators;
 
 class ValidationService {
@@ -28,6 +30,9 @@ class ValidationService {
   static const int PROFILE_NAME_MIN_LENGTH = 1;
   static const int PROFILE_LOCATION_MAX_LENGTH = 64;
   static const int PROFILE_BIO_MAX_LENGTH = 150;
+  static const int POST_IMAGE_MAX_SIZE = 20971520;
+  static const int AVATAR_IMAGE_MAX_SIZE = 10485760;
+  static const int COVER_IMAGE_MAX_SIZE = 10485760;
 
   void setAuthApiService(AuthApiService authApiService) {
     _authApiService = authApiService;
@@ -212,6 +217,21 @@ class ValidationService {
   bool isNameAllowedLength(String name) {
     return name.length >= PROFILE_NAME_MIN_LENGTH &&
         name.length <= PROFILE_NAME_MAX_LENGTH;
+  }
+
+  Future<bool> isImageAllowedSize(File image, OBImageType type) async {
+    int size = await image.length();
+    return size <= getAllowedImageSize(type);
+  }
+
+  int getAllowedImageSize(OBImageType type) {
+    if (type == OBImageType.avatar) {
+      return AVATAR_IMAGE_MAX_SIZE;
+    } else if (type == OBImageType.cover) {
+      return COVER_IMAGE_MAX_SIZE;
+    } else {
+      return POST_IMAGE_MAX_SIZE;
+    }
   }
 
   String validateUserUsername(String username) {


### PR DESCRIPTION
Fixes issue #170. `ImagePickerService` now throws an exception if the image is too large. The exception is caught by the widget that called the service, and an error toast is displayed.

Note: I wanted to access the image limit in the exception thrown by `ImagePickerService` so I added a getter in the `ValidationService` (used also by `ValidationService.isImageAllowedSize`) as a convenience method. This allows `ImagePickerService` to retrieve the limit and pass it to the exception constructor. Let me know if there is a better place (or way) for this.