### PR TITLE
🐛 Fixed error messages not fitting on narrow screens

### DIFF
--- a/lib/widgets/fields/text_form_field.dart
+++ b/lib/widgets/fields/text_form_field.dart
@@ -104,6 +104,7 @@ class OBTextFormField extends StatelessWidget {
                   labelText: decoration.labelText,
                   prefixIcon: decoration.prefixIcon,
                   prefixText: decoration.prefixText,
+                  errorMaxLines: decoration.errorMaxLines ?? 3
                 ),
               ),
               hasBorder ? const OBDivider() : const SizedBox()


### PR DESCRIPTION
Longer error messages may not fit on one row on more narrow screens, so I changed `errorMaxLines` in OBTextFormField's TextFormField to default to 3 (to allow for slightly smaller screens, and maybe longer errors in other languages). See image below.

![image](https://user-images.githubusercontent.com/7335682/55266622-4811e500-527e-11e9-8de2-3e7e0b1374e8.png)