### PR TITLE
✨ Post and comment text can now be copied using long-press.

### DIFF
--- a/lib/pages/home/pages/post_comments/widgets/post_comment/packages/post_comment_text.dart
+++ b/lib/pages/home/pages/post_comments/widgets/post_comment/packages/post_comment_text.dart
@@ -1,15 +1,19 @@
 import 'package:Openbook/models/post_comment.dart';
 import 'package:Openbook/models/theme.dart';
 import 'package:Openbook/provider.dart';
+import 'package:Openbook/services/toast.dart';
 import 'package:Openbook/widgets/theming/actionable_smart_text.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class OBPostCommentText extends StatelessWidget {
   final PostComment postComment;
   final VoidCallback onUsernamePressed;
   final Widget badge;
+  ToastService _toastService;
+  BuildContext _context;
 
-  const OBPostCommentText(this.postComment,
+  OBPostCommentText(this.postComment,
       {Key key, this.onUsernamePressed, this.badge})
       : super(key: key);
 
@@ -18,6 +22,9 @@ class OBPostCommentText extends StatelessWidget {
     var openbookProvider = OpenbookProvider.of(context);
     var themeService = openbookProvider.themeService;
     var themeValueParserService = openbookProvider.themeValueParserService;
+
+    _toastService = openbookProvider.toastService;
+    _context = context;
 
     return StreamBuilder(
         stream: themeService.themeChange,
@@ -53,14 +60,21 @@ class OBPostCommentText extends StatelessWidget {
               Row(
                 children: <Widget>[
                   Flexible(
-                    child: OBActionableSmartText(
-                      text: postComment.text,
-                    ),
-                  )
-                ],
+                      child: GestureDetector(
+                        onLongPress: _copyText,
+                        child: OBActionableSmartText(
+                          text: postComment.text,
+                        ),
+                      )
+                  )],
               )
             ],
           );
         });
+  }
+
+  void _copyText(){
+    Clipboard.setData(ClipboardData(text: postComment.text));
+    _toastService.toast(message: 'Text copied!', context: _context, type: ToastType.info);
   }
 }

--- a/lib/widgets/post/widgets/post-body/widgets/post_body_text.dart
+++ b/lib/widgets/post/widgets/post-body/widgets/post_body_text.dart
@@ -1,18 +1,34 @@
+import 'package:Openbook/provider.dart';
+import 'package:Openbook/services/toast.dart';
 import 'package:Openbook/models/post.dart';
 import 'package:Openbook/widgets/theming/actionable_smart_text.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 class OBPostBodyText extends StatelessWidget {
   final Post _post;
+  ToastService _toastService;
+  BuildContext _context;
 
   OBPostBodyText(this._post);
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-        padding: EdgeInsets.all(20.0),
-        child: OBActionableSmartText(
-          text: _post.getText(),
-        ));
+    _toastService = OpenbookProvider.of(context).toastService;
+    _context = context;
+
+    return GestureDetector(
+        onLongPress: _copyText,
+        child: Padding(
+            padding: EdgeInsets.all(20.0),
+            child: OBActionableSmartText(
+              text: _post.getText(),
+            ))
+    );
+  }
+
+  void _copyText() {
+    Clipboard.setData(ClipboardData(text: _post.getText()));
+    _toastService.toast(message: 'Text copied!', context: _context, type: ToastType.info);
   }
 }


### PR DESCRIPTION
Kinda fixes issue #211. Doesn't allow text to be selected, but at least it can be copied. Long-press on the text in a post or comment will now copy the (full) text to the clipboard and show an info toast to notify the user.

One question: Do we want to add "Copy post text" to the post actions, or leave it as-is?