### PR TITLE
🐛 Fix image preview being squashed in comment notification tile

### DIFF
--- a/lib/widgets/tiles/notification_tile/widgets/post_comment_notification_tile.dart
+++ b/lib/widgets/tiles/notification_tile/widgets/post_comment_notification_tile.dart
@@ -41,7 +41,7 @@ class OBPostCommentNotificationTile extends StatelessWidget {
           image: AdvancedNetworkImage(post.getImage(), useDiskCache: true),
           height: postImagePreviewSize,
           width: postImagePreviewSize,
-          fit: BoxFit.fill,
+          fit: BoxFit.cover,
         ),
       );
     }


### PR DESCRIPTION
The notification tile for reactions also uses a `BoxFit.cover` which looks much better for most images.