### PR TITLE
Fix statusbar on search page not changing color when needed on an iOS device 🍏

### DIFF
--- a/lib/pages/home/pages/search/search.dart
+++ b/lib/pages/home/pages/search/search.dart
@@ -12,6 +12,7 @@ import 'package:Openbook/services/httpie.dart';
 import 'package:Openbook/services/toast.dart';
 import 'package:Openbook/services/user.dart';
 import 'package:Openbook/widgets/search_bar.dart';
+import 'package:Openbook/widgets/nav_bars/themed_nav_bar.dart';
 import 'package:Openbook/widgets/theming/primary_color_container.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
@@ -88,11 +89,13 @@ class OBMainSearchPageState extends State<OBMainSearchPage> {
     }
 
     return CupertinoPageScaffold(
+        navigationBar: OBThemedNavigationBar(title: 'Search'),
         backgroundColor: Colors.white,
         child: OBPrimaryColorContainer(
           child: Column(
             children: <Widget>[
               SafeArea(
+                top: false,
                 bottom: false,
                 child: OBSearchBar(
                   onSearch: _onSearch,


### PR DESCRIPTION
This fixes the statusbar not changing color when needed on an iOS device 🍏
The search page was the only page without a navbar, adding makes the overall layout the same on all pages.

Feel free to shoot this down, if the lack of a statusbar was an intentional aesthetic choice.

See: https://openbook.canny.io/bugs/p/ios-statusbar-color-doesnt-always-change-on-switching-tabs