### PR TITLE
🐛 Fixed some more error messages not fitting on narrow screens

### DIFF
--- a/lib/pages/auth/login.dart
+++ b/lib/pages/auth/login.dart
@@ -249,6 +249,7 @@ class OBAuthLoginPageState extends State<OBAuthLoginPage> {
                               contentPadding: inputContentPadding,
                               labelText: usernameInputLabel,
                               border: OutlineInputBorder(),
+                              errorMaxLines: 3
                             ),
                             autocorrect: false,
                           ),

--- a/lib/pages/auth/reset_password/forgot_password_step.dart
+++ b/lib/pages/auth/reset_password/forgot_password_step.dart
@@ -232,6 +232,7 @@ class OBAuthForgotPasswordPageState extends State<OBAuthForgotPasswordPage> {
                               contentPadding: inputContentPadding,
                               labelText: usernameInputLabel,
                               border: OutlineInputBorder(),
+                              errorMaxLines: 3
                             ),
                             autocorrect: false,
                           ),
@@ -252,6 +253,7 @@ class OBAuthForgotPasswordPageState extends State<OBAuthForgotPasswordPage> {
                               contentPadding: inputContentPadding,
                               labelText: emailInputLabel,
                               border: OutlineInputBorder(),
+                              errorMaxLines: 3
                             ),
                             autocorrect: false,
                           ),


### PR DESCRIPTION
Realised that I missed the login and reset password screens when I fixed this the first time... 