### PR TITLE
Bug: Fix the thumbnail image aspect ratio in the 'new comment' notification

### DIFF
--- a/lib/widgets/tiles/notification_tile/widgets/post_comment_notification_tile.dart
+++ b/lib/widgets/tiles/notification_tile/widgets/post_comment_notification_tile.dart
@@ -41,7 +41,7 @@ class OBPostCommentNotificationTile extends StatelessWidget {
           image: AdvancedNetworkImage(post.getImage(), useDiskCache: true),
           height: postImagePreviewSize,
           width: postImagePreviewSize,
-          fit: BoxFit.fill,
+          fit: BoxFit.cover,
         ),
       );
     }


### PR DESCRIPTION
The thumbnail image in the 'new comment' notification is stretched. The aspect ratio of the image is ignored. It looks a little bit strange. 
This patch will cover the image like it is in the 'react to comment' comment.