### PR TITLE
✨ Move connection requests to a separate tab

### DIFF
--- a/lib/models/notifications/notification.dart
+++ b/lib/models/notifications/notification.dart
@@ -29,13 +29,6 @@ class OBNotification extends UpdatableModel<OBNotification> {
       this.read});
 
   static final factory = NotificationFactory();
-  static final postReaction = 'PR';
-  static final postComment = 'PC';
-  static final postCommentReply = 'PCR';
-  static final connectionRequest = 'CR';
-  static final connectionConfirmed = 'CC';
-  static final follow = 'F';
-  static final communityInvite = 'CI';
 
   factory OBNotification.fromJSON(Map<String, dynamic> json) {
     return factory.fromJson(json);
@@ -52,7 +45,7 @@ class OBNotification extends UpdatableModel<OBNotification> {
     }
 
     if (json.containsKey('notification_type')) {
-      type = factory.parseType(json['notification_type']);
+      type = NotificationType.parse(json['notification_type']);
     }
 
     if (json.containsKey('content_object')) {
@@ -82,7 +75,7 @@ class NotificationFactory extends UpdatableModelFactory<OBNotification> {
 
   @override
   OBNotification makeFromJson(Map json) {
-    NotificationType type = parseType(json['notification_type']);
+    NotificationType type = NotificationType.parse(json['notification_type']);
 
     return OBNotification(
         id: json['id'],
@@ -97,32 +90,6 @@ class NotificationFactory extends UpdatableModelFactory<OBNotification> {
   User parseUser(Map userData) {
     if (userData == null) return null;
     return User.fromJson(userData);
-  }
-
-  NotificationType parseType(String notificationTypeStr) {
-    if (notificationTypeStr == null) return null;
-
-    NotificationType notificationType;
-    if (notificationTypeStr == OBNotification.postReaction) {
-      notificationType = NotificationType.postReaction;
-    } else if (notificationTypeStr == OBNotification.postComment) {
-      notificationType = NotificationType.postComment;
-    } else if (notificationTypeStr == OBNotification.postCommentReply) {
-      notificationType = NotificationType.postCommentReply;
-    } else if (notificationTypeStr == OBNotification.connectionRequest) {
-      notificationType = NotificationType.connectionRequest;
-    } else if (notificationTypeStr == OBNotification.connectionConfirmed) {
-      notificationType = NotificationType.connectionConfirmed;
-    } else if (notificationTypeStr == OBNotification.follow) {
-      notificationType = NotificationType.follow;
-    } else if (notificationTypeStr == OBNotification.communityInvite) {
-      notificationType = NotificationType.communityInvite;
-    } else {
-      // Don't throw as we might introduce new notifications on the API which might not be yet in code
-      print('Unsupported notification type');
-    }
-
-    return notificationType;
   }
 
   dynamic parseContentObject(
@@ -164,12 +131,45 @@ class NotificationFactory extends UpdatableModelFactory<OBNotification> {
   }
 }
 
-enum NotificationType {
-  postReaction,
-  postComment,
-  postCommentReply,
-  connectionRequest,
-  connectionConfirmed,
-  follow,
-  communityInvite
+class NotificationType {
+  // Using a custom-built enum class to link the notification type strings
+  // directly to the matching enum constants.
+  // This class can still be used in switch statements as a normal enum.
+  final String _value;
+  const NotificationType._internal(this._value);
+  toString() => _value;
+
+  static const postReaction = const NotificationType._internal('PR');
+  static const postComment = const NotificationType._internal('PC');
+  static const postCommentReply = const NotificationType._internal('PCR');
+  static const connectionRequest = const NotificationType._internal('CR');
+  static const connectionConfirmed = const NotificationType._internal('CC');
+  static const follow = const NotificationType._internal('F');
+  static const communityInvite = const NotificationType._internal('CI');
+
+  static NotificationType parse(String string) {
+    if (string == null) return null;
+
+    NotificationType notificationType;
+    if (string == postReaction._value) {
+      notificationType = postReaction;
+    } else if (string == postComment._value) {
+      notificationType = postComment;
+    } else if (string == postCommentReply._value) {
+      notificationType = postCommentReply;
+    } else if (string == connectionRequest._value) {
+      notificationType = connectionRequest;
+    } else if (string == connectionConfirmed._value) {
+      notificationType = connectionConfirmed;
+    } else if (string == follow._value) {
+      notificationType = follow;
+    } else if (string == communityInvite._value) {
+      notificationType = communityInvite;
+    } else {
+      // Don't throw as we might introduce new notifications on the API which might not be yet in code
+      print('Unsupported notification type');
+    }
+
+    return notificationType;
+  }
 }

--- a/lib/models/push_notification.dart
+++ b/lib/models/push_notification.dart
@@ -5,15 +5,15 @@ class PushNotification {
     if (pushNotificationTypeStr == null) return null;
 
     PushNotificationType pushNotificationType;
-    if (pushNotificationTypeStr == OBNotification.postReaction) {
+    if (pushNotificationTypeStr == NotificationType.postReaction.toString()) {
       pushNotificationType = PushNotificationType.postReaction;
-    } else if (pushNotificationTypeStr == OBNotification.postComment) {
+    } else if (pushNotificationTypeStr == NotificationType.postComment.toString()) {
       pushNotificationType = PushNotificationType.postComment;
-    } else if (pushNotificationTypeStr == OBNotification.connectionRequest) {
+    } else if (pushNotificationTypeStr == NotificationType.connectionRequest.toString()) {
       pushNotificationType = PushNotificationType.connectionRequest;
-    } else if (pushNotificationTypeStr == OBNotification.follow) {
+    } else if (pushNotificationTypeStr == NotificationType.follow.toString()) {
       pushNotificationType = PushNotificationType.follow;
-    } else if (pushNotificationTypeStr == OBNotification.communityInvite) {
+    } else if (pushNotificationTypeStr == NotificationType.communityInvite.toString()) {
       pushNotificationType = PushNotificationType.communityInvite;
     } else {
       throw 'Unsupported push notification type';

--- a/lib/pages/home/pages/notifications/notifications.dart
+++ b/lib/pages/home/pages/notifications/notifications.dart
@@ -196,24 +196,28 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
   }
 
   Future<List<OBNotification>> _refreshGeneralNotifications() async {
-    var types = <String>['PR', 'PC', 'CC', 'F', 'CI'];
-
-    await _readNotifications(types: types);
-
-    NotificationsList notificationsList = await _userService.getNotifications(types: types);
-    return notificationsList.notifications;
+    var types = <NotificationType>[
+      NotificationType.postReaction,
+      NotificationType.postComment,
+      NotificationType.connectionConfirmed,
+      NotificationType.follow,
+      NotificationType.communityInvite
+    ];
+    return _refreshNotifications(types);
   }
 
   Future<List<OBNotification>> _refreshRequestNotifications() async {
-    var types = <String>['CR'];
+    return _refreshNotifications([NotificationType.connectionRequest]);
+  }
 
+  Future<List<OBNotification>> _refreshNotifications([List<NotificationType> types]) async {
     await _readNotifications(types: types);
 
     NotificationsList notificationsList = await _userService.getNotifications(types: types);
     return notificationsList.notifications;
   }
 
-  Future _readNotifications({List<String> types}) async {
+  Future _readNotifications({List<NotificationType> types}) async {
     if (_shouldMarkNotificationsAsRead &&
         _notificationsListController.hasItems()) {
       OBNotification firstItem = _notificationsListController.firstItem();
@@ -224,19 +228,25 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
 
   Future<List<OBNotification>> _loadMoreGeneralNotifications(
       List<OBNotification> currentNotifications) async {
-    OBNotification lastNotification = currentNotifications.last;
-    int lastNotificationId = lastNotification.id;
-    var types = <String>['PR', 'PC', 'CC', 'F', 'CI'];
-    NotificationsList moreNotifications =
-    await _userService.getNotifications(maxId: lastNotificationId, types: types);
-    return moreNotifications.notifications;
+    var types = <NotificationType>[
+      NotificationType.postReaction,
+      NotificationType.postComment,
+      NotificationType.connectionConfirmed,
+      NotificationType.follow,
+      NotificationType.communityInvite
+    ];
+    return _loadMoreNotifications(currentNotifications, types);
   }
 
   Future<List<OBNotification>> _loadMoreRequestNotifications(
       List<OBNotification> currentNotifications) async {
+    return _loadMoreNotifications(currentNotifications, [NotificationType.connectionRequest]);
+  }
+
+  Future<List<OBNotification>> _loadMoreNotifications(
+      List<OBNotification> currentNotifications, [List<NotificationType> types]) async {
     OBNotification lastNotification = currentNotifications.last;
     int lastNotificationId = lastNotification.id;
-    var types = <String>['CR'];
     NotificationsList moreNotifications =
     await _userService.getNotifications(maxId: lastNotificationId, types: types);
     return moreNotifications.notifications;

--- a/lib/pages/home/pages/notifications/notifications.dart
+++ b/lib/pages/home/pages/notifications/notifications.dart
@@ -196,22 +196,24 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
   }
 
   Future<List<OBNotification>> _refreshGeneralNotifications() async {
-    await _readNotifications();
-
     var types = <String>['PR', 'PC', 'CC', 'F', 'CI'];
+
+    await _readNotifications(types: types);
+
     NotificationsList notificationsList = await _userService.getNotifications(types: types);
     return notificationsList.notifications;
   }
 
   Future<List<OBNotification>> _refreshRequestNotifications() async {
-    await _readNotifications();
-
     var types = <String>['CR'];
+
+    await _readNotifications(types: types);
+
     NotificationsList notificationsList = await _userService.getNotifications(types: types);
     return notificationsList.notifications;
   }
 
-  Future _readNotifications({List<NotificationType> types}) async {
+  Future _readNotifications({List<String> types}) async {
     if (_shouldMarkNotificationsAsRead &&
         _notificationsListController.hasItems()) {
       OBNotification firstItem = _notificationsListController.firstItem();

--- a/lib/pages/home/pages/notifications/notifications.dart
+++ b/lib/pages/home/pages/notifications/notifications.dart
@@ -196,23 +196,17 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
   }
 
   Future<List<OBNotification>> _refreshGeneralNotifications() async {
-    var types = <NotificationType>[
-      NotificationType.postReaction,
-      NotificationType.postComment,
-      NotificationType.connectionConfirmed,
-      NotificationType.follow,
-      NotificationType.communityInvite
-    ];
-    return _refreshNotifications(types);
+    await _readNotifications();
+
+    var types = <String>['PR', 'PC', 'CC', 'F', 'CI'];
+    NotificationsList notificationsList = await _userService.getNotifications(types: types);
+    return notificationsList.notifications;
   }
 
   Future<List<OBNotification>> _refreshRequestNotifications() async {
-    return _refreshNotifications([NotificationType.connectionRequest]);
-  }
+    await _readNotifications();
 
-  Future<List<OBNotification>> _refreshNotifications([List<NotificationType> types]) async {
-    await _readNotifications(types: types);
-
+    var types = <String>['CR'];
     NotificationsList notificationsList = await _userService.getNotifications(types: types);
     return notificationsList.notifications;
   }
@@ -228,25 +222,19 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
 
   Future<List<OBNotification>> _loadMoreGeneralNotifications(
       List<OBNotification> currentNotifications) async {
-    var types = <NotificationType>[
-      NotificationType.postReaction,
-      NotificationType.postComment,
-      NotificationType.connectionConfirmed,
-      NotificationType.follow,
-      NotificationType.communityInvite
-    ];
-    return _loadMoreNotifications(currentNotifications, types);
+    OBNotification lastNotification = currentNotifications.last;
+    int lastNotificationId = lastNotification.id;
+    var types = <String>['PR', 'PC', 'CC', 'F', 'CI'];
+    NotificationsList moreNotifications =
+    await _userService.getNotifications(maxId: lastNotificationId, types: types);
+    return moreNotifications.notifications;
   }
 
   Future<List<OBNotification>> _loadMoreRequestNotifications(
       List<OBNotification> currentNotifications) async {
-    return _loadMoreNotifications(currentNotifications, [NotificationType.connectionRequest]);
-  }
-
-  Future<List<OBNotification>> _loadMoreNotifications(
-      List<OBNotification> currentNotifications, [List<NotificationType> types]) async {
     OBNotification lastNotification = currentNotifications.last;
     int lastNotificationId = lastNotification.id;
+    var types = <String>['CR'];
     NotificationsList moreNotifications =
     await _userService.getNotifications(maxId: lastNotificationId, types: types);
     return moreNotifications.notifications;

--- a/lib/pages/home/pages/notifications/notifications.dart
+++ b/lib/pages/home/pages/notifications/notifications.dart
@@ -196,27 +196,29 @@ class OBNotificationsPageState extends State<OBNotificationsPage>
   }
 
   Future<List<OBNotification>> _refreshGeneralNotifications() async {
-    await _readNotifications();
-
     var types = <String>['PR', 'PC', 'CC', 'F', 'CI'];
+
+    await _readNotifications(types: types);
+
     NotificationsList notificationsList = await _userService.getNotifications(types: types);
     return notificationsList.notifications;
   }
 
   Future<List<OBNotification>> _refreshRequestNotifications() async {
-    await _readNotifications();
-
     var types = <String>['CR'];
+
+    await _readNotifications(types: types);
+
     NotificationsList notificationsList = await _userService.getNotifications(types: types);
     return notificationsList.notifications;
   }
 
-  Future _readNotifications() async {
+  Future _readNotifications({List<String> types}) async {
     if (_shouldMarkNotificationsAsRead &&
         _notificationsListController.hasItems()) {
       OBNotification firstItem = _notificationsListController.firstItem();
       int maxId = firstItem.id;
-      await _userService.readNotifications(maxId: maxId);
+      await _userService.readNotifications(maxId: maxId, types: types);
     }
   }
 

--- a/lib/services/notifications_api.dart
+++ b/lib/services/notifications_api.dart
@@ -1,3 +1,4 @@
+import 'package:Openbook/models/notifications/notification.dart';
 import 'package:Openbook/services/httpie.dart';
 import 'package:Openbook/services/string_template.dart';
 
@@ -25,28 +26,29 @@ class NotificationsApiService {
     apiURL = newApiURL;
   }
 
-  Future<HttpieResponse> getNotifications({int maxId, int count, List<String> types}) {
+  Future<HttpieResponse> getNotifications({int maxId, int count, List<NotificationType> types}) {
     Map<String, dynamic> queryParams = {};
 
     if (maxId != null) queryParams['max_id'] = maxId;
 
     if (count != null) queryParams['count'] = count;
 
-    if (types != null) queryParams['types'] = types;
+    if (types != null)
+      queryParams['types'] = types.map<String>((type) => type.toString()).toList();
 
     String url = _makeApiUrl(NOTIFICATIONS_PATH);
     return _httpService.get(url,
         appendAuthorizationToken: true, queryParameters: queryParams);
   }
 
-  Future<HttpieResponse> readNotifications({int maxId, List<String> types}) {
+  Future<HttpieResponse> readNotifications({int maxId, List<NotificationType> types}) {
     String url = _makeApiUrl(NOTIFICATIONS_READ_PATH);
     Map<String, dynamic> body = {};
 
     if (maxId != null) body['max_id'] = maxId.toString();
 
     if (types != null) {
-      body['types'] = types.join(',');
+      body['types'] = types.map<String>((type) => type.toString()).join(',');
     }
 
     return _httpService.post(url, body: body, appendAuthorizationToken: true);

--- a/lib/services/notifications_api.dart
+++ b/lib/services/notifications_api.dart
@@ -26,15 +26,14 @@ class NotificationsApiService {
     apiURL = newApiURL;
   }
 
-  Future<HttpieResponse> getNotifications({int maxId, int count, List<NotificationType> types}) {
+  Future<HttpieResponse> getNotifications({int maxId, int count, List<String> types}) {
     Map<String, dynamic> queryParams = {};
 
     if (maxId != null) queryParams['max_id'] = maxId;
 
     if (count != null) queryParams['count'] = count;
 
-    if (types != null)
-      queryParams['types'] = types.map<String>((type) => type.toString()).toList();
+    if (types != null) queryParams['types'] = types;
 
     String url = _makeApiUrl(NOTIFICATIONS_PATH);
     return _httpService.get(url,

--- a/lib/services/notifications_api.dart
+++ b/lib/services/notifications_api.dart
@@ -39,11 +39,15 @@ class NotificationsApiService {
         appendAuthorizationToken: true, queryParameters: queryParams);
   }
 
-  Future<HttpieResponse> readNotifications({int maxId}) {
+  Future<HttpieResponse> readNotifications({int maxId, List<String> types}) {
     String url = _makeApiUrl(NOTIFICATIONS_READ_PATH);
     Map<String, dynamic> body = {};
 
     if (maxId != null) body['max_id'] = maxId.toString();
+
+    if (types != null) {
+      body['types'] = types.join(',');
+    }
 
     return _httpService.post(url, body: body, appendAuthorizationToken: true);
   }

--- a/lib/services/notifications_api.dart
+++ b/lib/services/notifications_api.dart
@@ -40,14 +40,14 @@ class NotificationsApiService {
         appendAuthorizationToken: true, queryParameters: queryParams);
   }
 
-  Future<HttpieResponse> readNotifications({int maxId, List<NotificationType> types}) {
+  Future<HttpieResponse> readNotifications({int maxId, List<String> types}) {
     String url = _makeApiUrl(NOTIFICATIONS_READ_PATH);
     Map<String, dynamic> body = {};
 
     if (maxId != null) body['max_id'] = maxId.toString();
 
     if (types != null) {
-      body['types'] = types.map<String>((type) => type.toString()).join(',');
+      body['types'] = types.join(',');
     }
 
     return _httpService.post(url, body: body, appendAuthorizationToken: true);

--- a/lib/services/notifications_api.dart
+++ b/lib/services/notifications_api.dart
@@ -26,28 +26,29 @@ class NotificationsApiService {
     apiURL = newApiURL;
   }
 
-  Future<HttpieResponse> getNotifications({int maxId, int count, List<String> types}) {
+  Future<HttpieResponse> getNotifications({int maxId, int count, List<NotificationType> types}) {
     Map<String, dynamic> queryParams = {};
 
     if (maxId != null) queryParams['max_id'] = maxId;
 
     if (count != null) queryParams['count'] = count;
 
-    if (types != null) queryParams['types'] = types;
+    if (types != null)
+      queryParams['types'] = types.map<String>((type) => type.toString()).toList();
 
     String url = _makeApiUrl(NOTIFICATIONS_PATH);
     return _httpService.get(url,
         appendAuthorizationToken: true, queryParameters: queryParams);
   }
 
-  Future<HttpieResponse> readNotifications({int maxId, List<String> types}) {
+  Future<HttpieResponse> readNotifications({int maxId, List<NotificationType> types}) {
     String url = _makeApiUrl(NOTIFICATIONS_READ_PATH);
     Map<String, dynamic> body = {};
 
     if (maxId != null) body['max_id'] = maxId.toString();
 
     if (types != null) {
-      body['types'] = types.join(',');
+      body['types'] = types.map<String>((type) => type.toString()).join(',');
     }
 
     return _httpService.post(url, body: body, appendAuthorizationToken: true);

--- a/lib/services/notifications_api.dart
+++ b/lib/services/notifications_api.dart
@@ -25,12 +25,14 @@ class NotificationsApiService {
     apiURL = newApiURL;
   }
 
-  Future<HttpieResponse> getNotifications({int maxId, int count}) {
+  Future<HttpieResponse> getNotifications({int maxId, int count, List<String> types}) {
     Map<String, dynamic> queryParams = {};
 
     if (maxId != null) queryParams['max_id'] = maxId;
 
     if (count != null) queryParams['count'] = count;
+
+    if (types != null) queryParams['types'] = types;
 
     String url = _makeApiUrl(NOTIFICATIONS_PATH);
     return _httpService.get(url,

--- a/lib/services/user.dart
+++ b/lib/services/user.dart
@@ -1325,7 +1325,7 @@ class UserService {
     return OBNotification.fromJSON(json.decode(response.body));
   }
 
-  Future<void> readNotifications({int maxId, List<NotificationType> types}) async {
+  Future<void> readNotifications({int maxId, List<String> types}) async {
     HttpieResponse response =
         await _notificationsApiService.readNotifications(maxId: maxId, types: types);
     _checkResponseIsOk(response);

--- a/lib/services/user.dart
+++ b/lib/services/user.dart
@@ -1325,9 +1325,9 @@ class UserService {
     return OBNotification.fromJSON(json.decode(response.body));
   }
 
-  Future<void> readNotifications({int maxId}) async {
+  Future<void> readNotifications({int maxId, List<String> types}) async {
     HttpieResponse response =
-        await _notificationsApiService.readNotifications(maxId: maxId);
+        await _notificationsApiService.readNotifications(maxId: maxId, types: types);
     _checkResponseIsOk(response);
   }
 

--- a/lib/services/user.dart
+++ b/lib/services/user.dart
@@ -1311,7 +1311,7 @@ class UserService {
     return CategoriesList.fromJson(json.decode(response.body));
   }
 
-  Future<NotificationsList> getNotifications({int maxId, int count, List<String> types}) async {
+  Future<NotificationsList> getNotifications({int maxId, int count, List<NotificationType> types}) async {
     HttpieResponse response = await _notificationsApiService.getNotifications(
         maxId: maxId, count: count, types: types);
     _checkResponseIsOk(response);
@@ -1325,7 +1325,7 @@ class UserService {
     return OBNotification.fromJSON(json.decode(response.body));
   }
 
-  Future<void> readNotifications({int maxId, List<String> types}) async {
+  Future<void> readNotifications({int maxId, List<NotificationType> types}) async {
     HttpieResponse response =
         await _notificationsApiService.readNotifications(maxId: maxId, types: types);
     _checkResponseIsOk(response);

--- a/lib/services/user.dart
+++ b/lib/services/user.dart
@@ -1311,7 +1311,7 @@ class UserService {
     return CategoriesList.fromJson(json.decode(response.body));
   }
 
-  Future<NotificationsList> getNotifications({int maxId, int count, List<NotificationType> types}) async {
+  Future<NotificationsList> getNotifications({int maxId, int count, List<String> types}) async {
     HttpieResponse response = await _notificationsApiService.getNotifications(
         maxId: maxId, count: count, types: types);
     _checkResponseIsOk(response);

--- a/lib/services/user.dart
+++ b/lib/services/user.dart
@@ -1311,9 +1311,9 @@ class UserService {
     return CategoriesList.fromJson(json.decode(response.body));
   }
 
-  Future<NotificationsList> getNotifications({int maxId, int count}) async {
+  Future<NotificationsList> getNotifications({int maxId, int count, List<String> types}) async {
     HttpieResponse response = await _notificationsApiService.getNotifications(
-        maxId: maxId, count: count);
+        maxId: maxId, count: count, types: types);
     _checkResponseIsOk(response);
     return NotificationsList.fromJson(json.decode(response.body));
   }


### PR DESCRIPTION
Fixes issue #249 by splitting the notification page into two tabs, one for general notifications and one for requests.

Requires [OpenbookOrg/openbook-api/pull/305](https://github.com/OpenbookOrg/openbook-api/pull/305) to function properly (without it all notifications are shown in both tabs).

(Was halfway done with this by the time I noticed it was marked for "Openbook World". I guess we'll get it earlier than expected. 😅)

PS. I have no idea why my commits got duplicated when I rebased against develop... Will squash the commits before the final merge.