### PR TITLE
🐛 Fixed exception when refreshing empty notification list

### DIFF
--- a/lib/widgets/http_list.dart
+++ b/lib/widgets/http_list.dart
@@ -99,15 +99,17 @@ class OBHttpListState<T> extends State<OBHttpList<T>> {
   }
 
   void scrollToTop() {
-    if (_listScrollController.offset == 0) {
-      _listRefreshIndicatorKey.currentState.show();
-    }
+    if (_listScrollController.hasClients) {
+      if (_listScrollController.offset == 0) {
+        _listRefreshIndicatorKey.currentState.show();
+      }
 
-    _listScrollController.animateTo(
-      0.0,
-      curve: Curves.easeOut,
-      duration: const Duration(milliseconds: 300),
-    );
+      _listScrollController.animateTo(
+        0.0,
+        curve: Curves.easeOut,
+        duration: const Duration(milliseconds: 300),
+      );
+    }
   }
 
   void dispose() {
@@ -270,7 +272,9 @@ class OBHttpListState<T> extends State<OBHttpList<T>> {
     await (shouldUseRefreshIndicator
         ? _listRefreshIndicatorKey.currentState.show()
         : _refreshList());
-    if (shouldScrollToTop && _listScrollController.offset != 0) {
+    if (shouldScrollToTop &&
+        _listScrollController.hasClients &&
+        _listScrollController.offset != 0) {
       scrollToTop();
     }
   }


### PR DESCRIPTION
If the notification list is empty the tab doesn't contain a scroll view. This wasn't controlled for when tapping the notification icon (to refresh/scroll to top) so it tried to scroll to top anyway, causing an exception to occur (can't scroll a scroll view that doesn't exist).