### PR TITLE
Bug/zoomable photo sentry error

### DIFF
--- a/lib/pages/home/modals/zoomable_photo.dart
+++ b/lib/pages/home/modals/zoomable_photo.dart
@@ -194,6 +194,7 @@ class OBZoomablePhotoModalState extends State<OBZoomablePhotoModal>
   }
 
   void _updateRotationValues() {
+    if (startDragDetails == null) return;
     double screenWidth = MediaQuery.of(context).size.width;
     double screenHeight = MediaQuery.of(context).size.height;
     double screenMid = screenWidth / 2;


### PR DESCRIPTION
While I cannot re-produce this on localhost, added a null check to the function that was causing the error on sentry, to be safe.